### PR TITLE
Validación de rol y privilegios. Casos de uso retornan texto plano.

### DIFF
--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -21,6 +21,7 @@ export class AuthController {
       const token = this.tokenService.generate({
         sub: user.id!,
         email: user.email,
+        role: user.role
       });
   
       return {
@@ -40,6 +41,7 @@ export class AuthController {
       const token = this.tokenService.generate({
         sub: user.id!,
         email: user.email,
+        role: user.role,
       });
   
       return {

--- a/src/modules/auth/infrastructure/services/jwt-token.service.ts
+++ b/src/modules/auth/infrastructure/services/jwt-token.service.ts
@@ -5,7 +5,7 @@ import { JwtService } from '@nestjs/jwt';
 export class JwtTokenService {
   constructor(private readonly jwtService: JwtService) {}
 
-  generate(payload: { sub: string; email: string }) {
+  generate(payload: { sub: string; email: string; role: string }){
     return this.jwtService.sign(payload);
   }
 }

--- a/src/modules/users/application/dto/change-password.dto.ts
+++ b/src/modules/users/application/dto/change-password.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsString()
+  oldPassword: string;
+
+  @IsString()
+  @MinLength(6)
+  newPassword: string;
+}

--- a/src/modules/users/application/use-cases/change-password.use-case.ts
+++ b/src/modules/users/application/use-cases/change-password.use-case.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable, NotFoundException, UnauthorizedException} from '@nestjs/common';
+import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
+import * as bcrypt from 'bcrypt';
+import { ChangePasswordInput } from '../../domain/types/change-password-input';
+
+
+@Injectable()
+export class ChangePasswordUseCase {
+  constructor(
+    @Inject(IUserRepository)
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  async execute( userId:string, data: ChangePasswordInput): Promise<{ success: boolean; message: string }> {
+    const user = await this.userRepository.findById(userId);
+    if (!user)  throw new NotFoundException('Usuario no encontrado');
+
+    const valid = await bcrypt.compare(data.oldPassword, user.password);
+    if (!valid) throw new  UnauthorizedException('La contraseña anterior es incorrecta');
+
+    const hashedNewPassword = await bcrypt.hash(data.newPassword, 10);
+    await this.userRepository.update(userId, { password: hashedNewPassword });
+
+    return {
+      success: true,
+      message: 'Contraseña actualizada correctamente',
+    };
+  }
+}

--- a/src/modules/users/application/use-cases/delete.use-case.ts
+++ b/src/modules/users/application/use-cases/delete.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
 
 @Injectable()
@@ -8,10 +8,17 @@ export class DeleteUserUseCase {
     private readonly userRepository: IUserRepository,
   ) {}
 //se medifico el caso de uso para que no devuelva un void 
-  async execute(id: string): Promise<boolean> {
-    const user = await this.userRepository.findById(id);
-    if (!user) return false;
 
-    return await this.userRepository.delete(id);
+
+  async execute(id: string, userRole: string): Promise<boolean> {
+  if (userRole !== 'admin') {
+    throw new ForbiddenException('Solo un administrador puede eliminar usuarios.');
   }
+
+  const user = await this.userRepository.findById(id);
+  if (!user) return false;
+
+  return await this.userRepository.delete(id);
+}
+
 }

--- a/src/modules/users/application/use-cases/get-all-users.use-case.ts.ts
+++ b/src/modules/users/application/use-cases/get-all-users.use-case.ts.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable, ForbiddenException } from '@nestjs/common';
+import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
+import { UserOutput } from '../../domain/types/user-output.type';
+
+@Injectable()
+export class GetAllUsersUseCase {
+  constructor(
+    @Inject(IUserRepository)
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  async execute(currentUserRole: string): Promise<UserOutput[]> {
+    if (currentUserRole !== 'admin') {
+      throw new ForbiddenException('No tienes permisos para ver todos los usuarios');
+    }
+
+    const users = await this.userRepository.findAllUsers();
+
+    return users.map(user => ({
+      id: user.id!,
+      name: user.name,
+      last_name: user.last_name,
+      email: user.email,
+      active: user.active,
+      role: user.role,
+    }));
+  }
+}

--- a/src/modules/users/application/use-cases/get-user-by-id.use-case.ts
+++ b/src/modules/users/application/use-cases/get-user-by-id.use-case.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable, ForbiddenException } from '@nestjs/common';
+import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
+import { UserOutput } from '../../domain/types/user-output.type';
+
+@Injectable()
+export class GetUserByIdUseCase {
+  constructor(
+    @Inject(IUserRepository)
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  async execute(requestingUserRole: string, id: string): Promise<UserOutput | null> {
+    if (requestingUserRole !== 'admin') {
+      throw new ForbiddenException('No tienes permisos para acceder a este recurso');
+    }
+
+    const user = await this.userRepository.findById(id);
+
+    if (!user?.id) return null;
+
+    return {
+      id: user.id,
+      name: user.name,
+      last_name: user.last_name,
+      email: user.email,
+      active: user.active,
+      role: user.role,
+    };
+  }
+}

--- a/src/modules/users/application/use-cases/get-user-profile.use-case.ts
+++ b/src/modules/users/application/use-cases/get-user-profile.use-case.ts
@@ -1,16 +1,23 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
-import { User } from '../../domain/entities/user.entity';
+import { UserOutput } from '../../domain/types/user-output.type';
 
 @Injectable()
 export class GetUserProfileUseCase {
   constructor(private readonly userRepository: IUserRepository) {}
 
-  async execute(userId: string): Promise<User> {
+  async execute(userId: string): Promise<UserOutput>{
     const user = await this.userRepository.findById(userId);
     if (!user) {
       throw new NotFoundException('User not found');
     }
-    return user;
+   return {
+        id: user.id!,
+        name: user.name,
+        last_name: user.last_name,
+        email: user.email,
+        active: user.active,
+        role: user.role,
+     }
   }
 }

--- a/src/modules/users/application/use-cases/register.use-case.ts
+++ b/src/modules/users/application/use-cases/register.use-case.ts
@@ -1,30 +1,34 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
-import { User } from '../../domain/entities/user.entity';
 import { RegisterUserInput } from '../../domain/types/register-user-input';
 import * as bcrypt from 'bcrypt';
+import { UserOutput } from '../../domain/types/user-output.type';
 
 @Injectable()
 export class RegisterUseCase {
   constructor(
+    @Inject(IUserRepository)
     private readonly userRepository: IUserRepository,
   ) {}
 
-  async execute(data: RegisterUserInput): Promise<User> {
+  async execute(data: RegisterUserInput): Promise<UserOutput> {
     const existing = await this.userRepository.findByEmail(data.email);
-    if (existing) throw new Error('Correo ya registrado');
+    if (existing) throw new Error('Correo ya registrado');{
+     if (data.password) {
+      data.password = await bcrypt.hash(data.password, 10);
+     }
+     
+     const created = await this.userRepository.create(data);
 
-    const hashedPassword = await bcrypt.hash(data.password, 10);
-
-    const user = new User(
-      data.name,
-      data.last_name,
-      data.email,
-      hashedPassword,
-      data.role,
-      data.active,
-    );
-
-    return await this.userRepository.create(user);
+      return {
+        id: created.id!,
+        name: created.name,
+        last_name: created.last_name,
+        email: created.email,
+        active: created.active,
+        role: created.role,
+     };
+    }  
   }
 }
+

--- a/src/modules/users/application/use-cases/update-use-case.ts
+++ b/src/modules/users/application/use-cases/update-use-case.ts
@@ -1,20 +1,33 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { IUserRepository } from '../../domain/interfaces/user-repository.interface';
-import { User } from '../../domain/entities/user.entity';
 import { UpdateUserInput } from '../../domain/types/update-user-input ';
 import * as bcrypt from 'bcrypt';
+import { UserOutput } from '../../domain/types/user-output.type';
 
 @Injectable()
 export class UpdateUserUseCase {
   constructor(private readonly userRepository: IUserRepository) {}
 
-  async execute(id: string, data: UpdateUserInput): Promise<User> {
-    if (data.password) {
-    data.password = await bcrypt.hash(data.password, 10);
-    }
-    const updatedUser = await this.userRepository.update(id, data);
-    return updatedUser;
 
- 
+  async execute(id: string, data: UpdateUserInput, currentUserRole: string): Promise<UserOutput> {
+  if (currentUserRole !== 'admin') {
+    throw new ForbiddenException('Solo el administrador puede editar usuarios.');
   }
+
+  if (data.password) {
+    data.password = await bcrypt.hash(data.password, 10);
+  }
+
+  const updated = await this.userRepository.update(id, data);
+
+  return {
+    id: updated.id!,
+    name: updated.name,
+    last_name: updated.last_name,
+    email: updated.email,
+    active: updated.active,
+    role: updated.role,
+  };
+}
+
 }

--- a/src/modules/users/domain/interfaces/user-repository.interface.ts
+++ b/src/modules/users/domain/interfaces/user-repository.interface.ts
@@ -4,6 +4,7 @@ export abstract class IUserRepository {
   abstract create(user: User): Promise<User>;
   abstract findByEmail(email: string): Promise<User | null>;
   abstract findById(id: string): Promise<User | null>;
+  abstract findAllUsers(): Promise<User[]>;
   abstract update(id: string, data: Partial<User>): Promise<User>;
   //se cambios el tipo de retorno para que sea un bboolean
   abstract delete(id: string): Promise<boolean>;

--- a/src/modules/users/domain/types/change-password-input.ts
+++ b/src/modules/users/domain/types/change-password-input.ts
@@ -1,0 +1,4 @@
+export type ChangePasswordInput = {
+  oldPassword: string;
+  newPassword: string;
+};

--- a/src/modules/users/domain/types/jwt-payload.type.ts
+++ b/src/modules/users/domain/types/jwt-payload.type.ts
@@ -1,4 +1,5 @@
 export type JwtPayload = {
   sub: string;
   email: string;
+  role: string;
 };

--- a/src/modules/users/domain/types/user-output.type.ts
+++ b/src/modules/users/domain/types/user-output.type.ts
@@ -1,0 +1,8 @@
+export type UserOutput = {
+  id?: string;
+  name: string;
+  last_name: string;
+  email: string;
+  active: boolean;
+  role: string;
+};

--- a/src/modules/users/infraestructure/controllers/user.controller.ts
+++ b/src/modules/users/infraestructure/controllers/user.controller.ts
@@ -5,6 +5,9 @@ import { Request } from 'express';
 import { DeleteUserUseCase } from '../../application/use-cases/delete.use-case';
 import { UpdateUserUseCase } from '../../application/use-cases/update-use-case';
 import { UpdateUserDto } from '../../application/dto/update-user.dto';
+import { GetAllUsersUseCase } from '../../application/use-cases/get-all-users.use-case.ts';
+import { UserOutput } from '../../domain/types/user-output.type';
+import { GetUserByIdUseCase } from '../../application/use-cases/get-user-by-id.use-case';
 
 
 @Controller('users')
@@ -13,34 +16,43 @@ export class UserController {
     private readonly getUserProfileUseCase: GetUserProfileUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
     private readonly updateUserUseCase: UpdateUserUseCase,
+    private readonly getAllUsers: GetAllUsersUseCase,
+    private readonly getUserById : GetUserByIdUseCase,
   ) {}
+
+  
+  @Get()
+  async findAllUsers(@Req() req: Request): Promise<UserOutput[]> {
+    return this.getAllUsers.execute(req.user.role);
+  }
 
   @Get('me')
   async getProfile(@Req() req: Request) {
     const userId = req.user.sub;
-    const user = await this.getUserProfileUseCase.execute(userId);
-
-    return {
-      id: user.id,
-      name: user.name,
-      last_name: user.last_name,
-      email: user.email,
-      active: user.active,
-    };
+    return await this.getUserProfileUseCase.execute(userId);
   }
 
 
-//e l metodo dsevuelve el boolean y se ajusta el tipo de retorno
-async deleteUser(@Param('id') id: string): Promise<{ success: boolean }> {
-  const result = await this.deleteUserUseCase.execute(id);
+  @Get(':id')
+  async findById(@Param('id') id: string, @Req() req: Request): Promise<UserOutput | null> {
+    return this.getUserById.execute(req.user.role, id);
+  }
+
+
+
+  //e l metodo dsevuelve el boolean y se ajusta el tipo de retorno
+  @Delete(':id')
+  async deleteUser(@Param('id') id: string, @Req() req: Request): Promise<{ success: boolean }> {
+  const result = await this.deleteUserUseCase.execute(id, req.user.role);
   return { success: result };
 }
 
+
   @Patch(':id')
-  async update(@Param('id') id: string, @Body() data: UpdateUserDto) {
-    const user = await this.updateUserUseCase.execute(id, data);
-    return user;
-  }
+  async update(@Param('id') id: string, @Body() dto: UpdateUserDto, @Req() req: Request) {
+  return await this.updateUserUseCase.execute(id, dto, req.user.role);
+}
+
 
 
 }

--- a/src/modules/users/infraestructure/controllers/user.controller.ts
+++ b/src/modules/users/infraestructure/controllers/user.controller.ts
@@ -8,6 +8,8 @@ import { UpdateUserDto } from '../../application/dto/update-user.dto';
 import { GetAllUsersUseCase } from '../../application/use-cases/get-all-users.use-case.ts';
 import { UserOutput } from '../../domain/types/user-output.type';
 import { GetUserByIdUseCase } from '../../application/use-cases/get-user-by-id.use-case';
+import { ChangePasswordDto } from '../../application/dto/change-password.dto';
+import { ChangePasswordUseCase } from '../../application/use-cases/change-password.use-case';
 
 
 @Controller('users')
@@ -16,14 +18,15 @@ export class UserController {
     private readonly getUserProfileUseCase: GetUserProfileUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
     private readonly updateUserUseCase: UpdateUserUseCase,
-    private readonly getAllUsers: GetAllUsersUseCase,
-    private readonly getUserById : GetUserByIdUseCase,
+    private readonly getAllUsersUseCase: GetAllUsersUseCase,
+    private readonly getUserByIdUseCase : GetUserByIdUseCase,
+    private readonly changePasswordUseCase : ChangePasswordUseCase,
   ) {}
 
   
   @Get()
   async findAllUsers(@Req() req: Request): Promise<UserOutput[]> {
-    return this.getAllUsers.execute(req.user.role);
+    return this.getAllUsersUseCase.execute(req.user.role);
   }
 
   @Get('me')
@@ -35,7 +38,7 @@ export class UserController {
 
   @Get(':id')
   async findById(@Param('id') id: string, @Req() req: Request): Promise<UserOutput | null> {
-    return this.getUserById.execute(req.user.role, id);
+    return this.getUserByIdUseCase.execute(req.user.role, id);
   }
 
 
@@ -46,6 +49,13 @@ export class UserController {
   const result = await this.deleteUserUseCase.execute(id, req.user.role);
   return { success: result };
 }
+
+  @Patch('change-password')
+  async changePassword(@Req() req:Request,@Body() dto: ChangePasswordDto ) {
+    const userId = req.user.sub;
+    return await this.changePasswordUseCase.execute(userId, dto);
+  }
+
 
 
   @Patch(':id')

--- a/src/modules/users/infraestructure/repositories/user.repository.ts
+++ b/src/modules/users/infraestructure/repositories/user.repository.ts
@@ -29,6 +29,11 @@ export class UserRepository implements IUserRepository {
     return record ? UserMapper.toEntity(record) : null;
   }
 
+  async findAllUsers(): Promise<User[]> {//Obtiene todos los registros de user y los mappea a entidad
+    const users = await this.prisma.user.findMany();
+    return users.map(UserMapper.toEntity);
+  }
+
   //se cambio el metodo anterior para que este devuelva un boolean 
   async delete(id: string): Promise<boolean> {
     try {

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -9,6 +9,7 @@ import { UpdateUserUseCase } from './application/use-cases/update-use-case';
 import { UserRepository } from './infraestructure/repositories/user.repository';
 import { GetAllUsersUseCase } from './application/use-cases/get-all-users.use-case.ts';
 import { GetUserByIdUseCase } from './application/use-cases/get-user-by-id.use-case';
+import { ChangePasswordUseCase } from './application/use-cases/change-password.use-case';
 
 
 @Module({
@@ -21,6 +22,7 @@ import { GetUserByIdUseCase } from './application/use-cases/get-user-by-id.use-c
     UpdateUserUseCase,
     GetAllUsersUseCase,
     GetUserByIdUseCase,
+    ChangePasswordUseCase,
     {
        provide: IUserRepository, 
        useClass: UserRepository,
@@ -34,6 +36,7 @@ import { GetUserByIdUseCase } from './application/use-cases/get-user-by-id.use-c
     UpdateUserUseCase,
     GetAllUsersUseCase,
     GetUserByIdUseCase,
+    ChangePasswordUseCase,
   ],
 })
 export class UsersModule {}

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -7,6 +7,8 @@ import { DeleteUserUseCase } from './application/use-cases/delete.use-case';
 import { IUserRepository } from './domain/interfaces/user-repository.interface';
 import { UpdateUserUseCase } from './application/use-cases/update-use-case';
 import { UserRepository } from './infraestructure/repositories/user.repository';
+import { GetAllUsersUseCase } from './application/use-cases/get-all-users.use-case.ts';
+import { GetUserByIdUseCase } from './application/use-cases/get-user-by-id.use-case';
 
 
 @Module({
@@ -17,6 +19,8 @@ import { UserRepository } from './infraestructure/repositories/user.repository';
     GetUserProfileUseCase,
     DeleteUserUseCase,
     UpdateUserUseCase,
+    GetAllUsersUseCase,
+    GetUserByIdUseCase,
     {
        provide: IUserRepository, 
        useClass: UserRepository,
@@ -28,6 +32,8 @@ import { UserRepository } from './infraestructure/repositories/user.repository';
     GetUserProfileUseCase,
     DeleteUserUseCase,
     UpdateUserUseCase,
+    GetAllUsersUseCase,
+    GetUserByIdUseCase,
   ],
 })
 export class UsersModule {}


### PR DESCRIPTION
Aparte de agregar la validación de rol en cada caso de uso, también cree un type general con la estructura de la entidad de user  para no hacer uso de esta en los casos de uso, ya que leí que no era ideal que las entidades salieran de la carpeta de dominio, por lo que usarlas en los casos de uso o controladores no es correcto, por la misma razón decidí retornar en texto plano lo que devuelve el repositorio en el caso de uso.

Por último, procedí a crear las funciones para obtener todos los usuarios, un usuario por id y el cambio de contraseña del usuario validando el rol si es necesario. 

Extra: note que el caso de uso para actualizar no tenía buena lógica por si llegasen a actualizar parámetros como contraseña.